### PR TITLE
Reduce number of samples

### DIFF
--- a/01-feature-selection.ipynb
+++ b/01-feature-selection.ipynb
@@ -811,7 +811,7 @@
     "    \n",
     "    best = kerberos_sampler.sample(kbqm, \n",
     "                                   qpu_sampler=qpu_sampler, \n",
-    "                                   qpu_reads=10000, \n",
+    "                                   qpu_reads=5000, \n",
     "                                   max_iter=1,\n",
     "                                   qpu_params={'label': 'Notebook - Feature Selection'}\n",
     "                                  ).first.sample\n",


### PR DESCRIPTION
We hit the runtime limit for Advantage 4 at over 7000 reads, so 5000 has a decent margin, and from a couple of runs, it looks as though results are good down to 1000 reads, so 5000 should be fine.  